### PR TITLE
Update scrolling when active leaf is fully visible or on the right

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -106,6 +106,10 @@ export default class SlidingPanesPlugin extends Plugin {
       leaf.style.position = "sticky";
       leaf.style.left = (i * this.settings.headerWidth) + "px";
       leaf.style.right = (((leafCount - i - 1) * this.settings.headerWidth) - this.settings.leafWidth) + "px";
+
+      // for use in focusLeaf
+      leaf.dataset.index = i;
+      leaf.dataset.total = leafCount;
     });
   }
 
@@ -120,12 +124,19 @@ export default class SlidingPanesPlugin extends Plugin {
     if (leaf != null) {
       // figure out which "number" leaf this is, and where we need to scroll to
       const left = parseInt(leaf.containerEl.style.left);
-      const leafNumber = left / this.settings.headerWidth;
+      const leafNumber = leaf.containerEl.dataset.index;
+      const leafCount = leaf.containerEl.dataset.total;
       const position = (leafNumber * this.settings.leafWidth) + left;
 
       const rootEl = rootSplit.containerEl;
-      if (rootEl.scrollLeft < position || rootEl.scrollLeft + rootEl.clientWidth > position + leaf.containerEl.clientWidth) {
+      const headersToRightWidth = (leafCount - leafNumber - 1) * this.settings.headerWidth;
+      if (rootEl.scrollLeft > position) { // it's too far left
         rootEl.scrollTo({ left: position - left, top: 0, behavior: 'smooth' });
+      } else if (rootEl.scrollLeft + rootEl.clientWidth < position + leaf.containerEl.clientWidth + headersToRightWidth) { // it's too far right
+        const numVisibleLeaves = (rootEl.clientWidth - (leafCount * this.settings.headerWidth)) / this.settings.leafWidth;
+        const otherVisibleLeavesWidth = this.settings.leafWidth * Math.max(0, numVisibleLeaves - 1);
+        const headersToLeftWidth = this.settings.headerWidth * leafNumber;
+        rootEl.scrollTo({ left: position - otherVisibleLeavesWidth - headersToLeftWidth, top: 0, behavior: 'smooth' });
       }
     }
   }


### PR DESCRIPTION
Update focusLeaf to scroll just far enough to make a leaf fully visible if it's out of view to the right.

Previously any time a leaf was activated it would always scroll so that the left side of the leaf was adjacent with the headers stacked on the left. This would happen even if the leaf was already fully visible or stacked to the right. This was unintuitive and jarring for me. I updated the code so that when a note is stacked to the right it only scrolls just far enough to make the leaf fully visible, with the right side of the note adjacent to the headers stacked to the right. If the leaf is already fully visible then it does nothing. I think this makes for a much more intuitive and pleasant user experience. I will include a gif shortly to demonstrate.

