### PR TITLE
Activate adjacent leaf when active leaf is closed

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -115,7 +115,6 @@ export default class SlidingPanesPlugin extends Plugin {
   }
 
   handleFileOpen = (e: any): void => {
-    console.log('handling file open');
     this.activateAdjacentLeafIfClosed(e);
     this.focusLeaf(e);
   };

--- a/main.ts
+++ b/main.ts
@@ -2,8 +2,10 @@ import './styles.scss'
 import { App, Plugin, PluginSettingTab, Setting } from 'obsidian';
 
 export default class SlidingPanesPlugin extends Plugin {
-
   settings: SlidingPanesSettings;
+
+	private leavesOpenCount: number = 0;
+	private activeLeafIndex: number = 0;
 
   async onInit() {
 
@@ -44,7 +46,7 @@ export default class SlidingPanesPlugin extends Plugin {
       this.app.workspace.on('layout-ready', this.layoutReady);
     }
     this.app.workspace.on('resize', this.recalculateLeaves);
-    this.app.workspace.on('file-open', this.focusLeaf);
+    this.app.workspace.on('file-open', this.handleFileOpen);
   }
 
   disable = () => {
@@ -61,7 +63,7 @@ export default class SlidingPanesPlugin extends Plugin {
     });
 
     this.app.workspace.off('resize', this.recalculateLeaves);
-    this.app.workspace.off('file-open', this.focusLeaf);
+    this.app.workspace.off('file-open', this.handleFileOpen);
   }
 
   layoutReady = () => {
@@ -106,7 +108,37 @@ export default class SlidingPanesPlugin extends Plugin {
       leaf.style.position = "sticky";
       leaf.style.left = (i * this.settings.headerWidth) + "px";
       leaf.style.right = (((leafCount - i - 1) * this.settings.headerWidth) - this.settings.leafWidth) + "px";
+
+			leaf.dataset.slidingPanesIndex = i;
+			leaf.dataset.slidingPanesCount = leafCount;
     });
+  }
+
+  handleFileOpen = (e: any): void => {
+    console.log('handling file open');
+    this.activateAdjacentLeafIfClosed(e);
+    this.focusLeaf(e);
+  };
+
+  activateAdjacentLeafIfClosed = (e: any): void => {
+		const workspaceEl = (this.app.workspace.rootSplit as any).containerEl;
+		const leaves = workspaceEl.querySelectorAll(":scope>div");
+    const leafCount = leaves.length;
+
+		if (leafCount < this.leavesOpenCount) {
+			let isActiveLeafSet: boolean = false;
+			this.app.workspace.iterateRootLeaves((leaf: any) => {
+				const index = parseInt(leaf.containerEl.dataset.slidingPanesIndex);
+				if (!isActiveLeafSet && (index === this.activeLeafIndex - 1 || index == this.activeLeafIndex + 1)) {
+					(this.app.workspace as any).setActiveLeaf(leaf);
+          isActiveLeafSet = true;
+				}
+			})
+    }
+
+		this.leavesOpenCount = leafCount;
+		this.recalculateLeaves();
+    this.activeLeafIndex = parseInt((this.app.workspace.activeLeaf as any).containerEl.dataset.slidingPanesIndex);
   }
 
   focusLeaf = (e: any) => {

--- a/main.ts
+++ b/main.ts
@@ -4,8 +4,8 @@ import { App, Plugin, PluginSettingTab, Setting } from 'obsidian';
 export default class SlidingPanesPlugin extends Plugin {
   settings: SlidingPanesSettings;
 
-	private leavesOpenCount: number = 0;
-	private activeLeafIndex: number = 0;
+  private leavesOpenCount: number = 0;
+  private activeLeafIndex: number = 0;
 
   async onInit() {
 
@@ -109,8 +109,8 @@ export default class SlidingPanesPlugin extends Plugin {
       leaf.style.left = (i * this.settings.headerWidth) + "px";
       leaf.style.right = (((leafCount - i - 1) * this.settings.headerWidth) - this.settings.leafWidth) + "px";
 
-			leaf.dataset.slidingPanesIndex = i;
-			leaf.dataset.slidingPanesCount = leafCount;
+      leaf.dataset.slidingPanesIndex = i;
+      leaf.dataset.slidingPanesCount = leafCount;
     });
   }
 
@@ -120,23 +120,23 @@ export default class SlidingPanesPlugin extends Plugin {
   };
 
   activateAdjacentLeafIfClosed = (e: any): void => {
-		const workspaceEl = (this.app.workspace.rootSplit as any).containerEl;
-		const leaves = workspaceEl.querySelectorAll(":scope>div");
+    const workspaceEl = (this.app.workspace.rootSplit as any).containerEl;
+    const leaves = workspaceEl.querySelectorAll(":scope>div");
     const leafCount = leaves.length;
 
-		if (leafCount < this.leavesOpenCount) {
-			let isActiveLeafSet: boolean = false;
-			this.app.workspace.iterateRootLeaves((leaf: any) => {
-				const index = parseInt(leaf.containerEl.dataset.slidingPanesIndex);
-				if (!isActiveLeafSet && (index === this.activeLeafIndex - 1 || index == this.activeLeafIndex + 1)) {
-					(this.app.workspace as any).setActiveLeaf(leaf);
+    if (leafCount < this.leavesOpenCount) {
+      let isActiveLeafSet: boolean = false;
+      this.app.workspace.iterateRootLeaves((leaf: any) => {
+        const index = parseInt(leaf.containerEl.dataset.slidingPanesIndex);
+        if (!isActiveLeafSet && (index === this.activeLeafIndex - 1 || index == this.activeLeafIndex + 1)) {
+          (this.app.workspace as any).setActiveLeaf(leaf);
           isActiveLeafSet = true;
-				}
-			})
+        }
+      })
     }
 
-		this.leavesOpenCount = leafCount;
-		this.recalculateLeaves();
+    this.leavesOpenCount = leafCount;
+    this.recalculateLeaves();
     this.activeLeafIndex = parseInt((this.app.workspace.activeLeaf as any).containerEl.dataset.slidingPanesIndex);
   }
 


### PR DESCRIPTION
This is a bit of a hacky way to go about it but it's the best I could come up with. Because the API doesn't offer a file-close event like it does a file-open event, and because the ability to inspect and traverse leaves is limited at this point, I had to manually track the leaves that were open and assign indexes to their DOM elements.

Resolves Issue #3 