### PR TITLE
Fix suggestion container appearing in the wrong place when on a non-leftmost leaf

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -221,7 +221,6 @@ export default class SlidingPanesPlugin extends Plugin {
       var previousTokens = lineTokens.filter((token: Token): boolean => token.start <= currentToken.start).reverse();
       const openBracketsToken = previousTokens.find((token: Token): boolean => token.string.contains('['));
 
-      // position the suggestion container to just underneath the end of the open brackets
       currentLinkPosition = { line: cursorPosition.line, ch: openBracketsToken.end };
     }
 
@@ -237,22 +236,11 @@ export default class SlidingPanesPlugin extends Plugin {
       scCoords.left -= scRight - appWidth;
     }
 
-    const verticalGap = 5;
-    scCoords.top += verticalGap;
-    const scBottom = scCoords.top + scNode.offsetHeight;
-
-    console.log({scBottom});
-    console.log({appHeight: appContainerEl.offsetHeight});
-    if (scBottom > appContainerEl.offsetHeight) {
-      const topOfLine = cmEditor.charCoords(cursorPosition, 'page').top; // using 'local' to take into account padding of the CodeMirror container
-      console.log({topOfLine});
-      scCoords.top = topOfLine - scNode.offsetHeight - verticalGap;
-    }
-
-    // set the coords
+    // set the left coord
+    // the top coord is set by Obsidian and is correct.
+    // it's also a pain to try to recalculate so I left it out.
 
     scNode.style.left = Math.max(scCoords.left, 0) + 'px';
-    scNode.style.top =  Math.max(scCoords.top, 0) + 'px';
   };
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,5 @@
   "isDesktopOnly": false,
   "js": "main.js",
   "css": "styles.css",
-  "version": "v3.0.2"
+  "version": "3.0.2"
 }


### PR DESCRIPTION
I accomplished this by adding a listener to the `appContainerEl` for when the suggestion container appears. When it does, the `positionSuggestionContainer` function uses the CodeMirror editor to determine the coordinates of the cursor. The suggestion container `left` coordinate is then set to be in line with the cursor. It should be noted that only the `left` coordinate is being set by this function. The main reason for this is that the `top` coordinate is already set by Obsidian and it's correct.

Fixes #9 