### PR TITLE
added the option to select the header text orientation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -152,8 +152,7 @@ export default class SlidingPanesPlugin extends Plugin {
         el.innerText += `body.plugin-sliding-panes .mod-root>.workspace-leaf{width:${this.settings.leafWidth + this.settings.headerWidth}px;}`;
       }
     }
-
-    var elems = document.getElementsByClassName('view-header-title');
+    
     if (this.settings.rotateHeaders){
       this.selectOrientation(this.settings.orienation);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import './styles.scss'
 import { FileView, Plugin, TAbstractFile, WorkspaceLeaf, WorkspaceItem, WorkspaceSplit } from 'obsidian';
 import { WorkspaceItemExt } from './obsidian-ext';
 import { Editor, Position, Token } from 'codemirror';
-import { SlidingPanesSettings, SlidingPanesSettingTab, SlidingPanesCommands } from './settings';
+import { SlidingPanesSettings, SlidingPanesSettingTab, SlidingPanesCommands, Orientation } from './settings';
 
 
 export default class SlidingPanesPlugin extends Plugin {
@@ -155,24 +155,14 @@ export default class SlidingPanesPlugin extends Plugin {
 
     var elems = document.getElementsByClassName('view-header-title');
     if (this.settings.rotateHeaders){
-      switch(this.settings.orienation){
-        case 'mixed':
-          for (var i = 0; i < elems.length; i++){
-            elems[i].setAttribute('style', 'text-orientation: mixed !important;');
-          }
-          break;
-        case 'upright':
-          for (var i = 0; i < elems.length; i++){
-            elems[i].setAttribute('style', 'text-orientation: upright !important;');
-          }      
-          break;
-        case 'sideway':
-          for (var i = 0; i < elems.length; i++){          
-            elems[i].setAttribute('style', 'text-orientation: sideway !important;'); 
-          }          
-          break;
-      }
+      this.selectOrientation(this.settings.orienation);
     }
+  }
+
+  selectOrientation(orient: Orientation) {
+    document.body.classList.toggle('plugin-sliding-select-orientation-mixed', orient == 'mixed');
+    document.body.classList.toggle('plugin-sliding-select-orientation-upright', orient == 'upright');
+    document.body.classList.toggle('plugin-sliding-select-orientation-sideway', orient == 'sideway');
   }
 
   handleResize = () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -152,6 +152,27 @@ export default class SlidingPanesPlugin extends Plugin {
         el.innerText += `body.plugin-sliding-panes .mod-root>.workspace-leaf{width:${this.settings.leafWidth + this.settings.headerWidth}px;}`;
       }
     }
+
+    var elems = document.getElementsByClassName('view-header-title');
+    if (this.settings.rotateHeaders){
+      switch(this.settings.orienation){
+        case 'mixed':
+          for (var i = 0; i < elems.length; i++){
+            elems[i].setAttribute('style', 'text-orientation: mixed !important;');
+          }
+          break;
+        case 'upright':
+          for (var i = 0; i < elems.length; i++){
+            elems[i].setAttribute('style', 'text-orientation: upright !important;');
+          }      
+          break;
+        case 'sideway':
+          for (var i = 0; i < elems.length; i++){          
+            elems[i].setAttribute('style', 'text-orientation: sideway !important;'); 
+          }          
+          break;
+      }
+    }
   }
 
   handleResize = () => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,7 @@
 import { App, Plugin, PluginSettingTab, Setting } from 'obsidian';
 
+export type Orientation = "sideway" | "mixed" | "upright"
+
 declare class SlidingPanesPlugin extends Plugin {
   settings: SlidingPanesSettings;
   disable(): void;
@@ -14,6 +16,7 @@ export class SlidingPanesSettings {
   disabled: boolean = false;
   rotateHeaders: boolean = true;
   headerAlt: boolean = false;
+  orienation: Orientation = "mixed";
   stackingEnabled: boolean = true;
 }
 
@@ -85,6 +88,21 @@ export class SlidingPanesSettingTab extends PluginSettingTab {
           this.plugin.saveData(this.plugin.settings);
           this.plugin.refresh();
         }));
+
+    new Setting(containerEl)
+    .setName("Select text orientation")
+    .setDesc("Select the header text orientation")
+    .addDropdown((dropdown) => {
+      dropdown.addOption("sideway", "Sideway")
+      dropdown.addOption("mixed", "Mixed")
+      dropdown.addOption("upright", "Upright")
+      dropdown.setValue(this.plugin.settings.orienation)
+      dropdown.onChange((value: Orientation) => {
+        this.plugin.settings.orienation = value;
+        this.plugin.saveData(this.plugin.settings);
+        this.plugin.refresh();
+      })
+    })        
 
     new Setting(containerEl)
       .setName("Toggle stacking")

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -118,3 +118,13 @@ body.plugin-sliding-panes-rotate-header.plugin-sliding-panes-header-alt .workspa
         margin-top: 10px;
     }
 }
+
+body.plugin-sliding-panes-rotate-header.plugin-sliding-select-orientation-sideway .workspace>.mod-root>.workspace-leaf>.workspace-leaf-content>.view-header {
+    text-orientation: sideways !important;
+}
+body.plugin-sliding-panes-rotate-header.plugin-sliding-select-orientation-mixed .workspace>.mod-root>.workspace-leaf>.workspace-leaf-content>.view-header {
+    text-orientation: mixed !important;
+}
+body.plugin-sliding-panes-rotate-header.plugin-sliding-select-orientation-upright .workspace>.mod-root>.workspace-leaf>.workspace-leaf-content>.view-header {
+    text-orientation: upright !important;
+}


### PR DESCRIPTION
added the option to select header text orientation specific for Japanese and Chinese users(we have vertical text writing culture)
three options:
- sideway 
- mixed 
- upright 

![スクリーンショット 2021-04-03 17 45 20](https://user-images.githubusercontent.com/50942816/113473604-6c27e280-94a5-11eb-8350-d2990580b0aa.png)
![スクリーンショット 2021-04-03 17 45 43](https://user-images.githubusercontent.com/50942816/113473608-6fbb6980-94a5-11eb-8cf4-9a6bafb1aad2.png)
